### PR TITLE
Removing identifiable requirement

### DIFF
--- a/Sources/CustomAlert/API+Item.swift
+++ b/Sources/CustomAlert/API+Item.swift
@@ -1,5 +1,5 @@
 //
-//  API+Identifiable.swift
+//  API+Item.swift
 //  CustomAlert
 //
 //  Created by David Walter on 28.02.24.
@@ -16,7 +16,7 @@ public extension View {
     /// All actions in an alert dismiss the alert after the action runs.
     ///
     /// - Parameters:
-    ///   - title: The optional title of the alert.
+    ///   - title: A `ViewBuilder` returing the alerts title.
     ///   - item: A binding to an optional source of truth for the alert.
     ///     When `item` is non-`nil`, the system passes the item's content to
     ///     the modifier's closure. You display this content in a alert that you
@@ -27,11 +27,11 @@ public extension View {
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
-        _ title: @autoclosure @escaping () -> Text? = nil,
+        @ViewBuilder _ title: @escaping (Item) -> Text? = { _ in nil },
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
+    ) -> some View where Content: View, Actions: View {
         modifier(
             CustomAlertHandler(
                 item: item,
@@ -60,12 +60,12 @@ public extension View {
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
-        _ title: LocalizedStringKey,
+        _ title: @escaping (Item) -> LocalizedStringKey,
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
-        self.customAlert(Text(title), item: item, content: content, actions: actions)
+    ) -> some View where Content: View, Actions: View {
+        self.customAlert({ item in Text(title(item)) }, item: item, content: content, actions: actions)
     }
     
     /// Presents an alert when a given condition is true
@@ -85,12 +85,12 @@ public extension View {
     @warn_unqualified_access
     @_disfavoredOverload
     func customAlert<Item, Title, Content, Actions>(
-        _ title: Title,
+        _ title: @escaping (Item) -> Title,
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Title: StringProtocol, Content: View, Actions: View {
-        self.customAlert(Text(title), item: item, content: content, actions: actions)
+    ) -> some View where Title: StringProtocol, Content: View, Actions: View {
+        self.customAlert({ item in Text(title(item)) }, item: item, content: content, actions: actions)
     }
     
     /// Presents an alert when a given condition is true, using an optional text view for
@@ -105,17 +105,17 @@ public extension View {
     ///     create that the system displays to the user. If `item` changes,
     ///     the system dismisses the alert and replaces it with a new one
     ///     using the same process.
-    ///   - title: Callback for the optional title of the alert.
+    ///   - title: A `ViewBuilder` returing the alerts title.
     ///   - content: A `ViewBuilder` returing the alerts main view.
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
         item: Binding<Item?>,
-        title: @escaping () -> Text?,
+        @ViewBuilder title: @escaping (Item) -> Text?,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
-        self.customAlert(title(), item: item, content: content, actions: actions)
+    ) -> some View where Content: View, Actions: View {
+        self.customAlert({ title($0) }, item: item, content: content, actions: actions)
     }
 }
 
@@ -126,7 +126,7 @@ public extension View {
     /// All actions in an alert dismiss the alert after the action runs.
     ///
     /// - Parameters:
-    ///   - title: The optional title of the alert.
+    ///   - title: A `ViewBuilder` returing the alerts title.
     ///   - item: A binding to an optional source of truth for the alert.
     ///     When `item` is non-`nil`, the system passes the item's content to
     ///     the modifier's closure. You display this content in a alert that you
@@ -138,12 +138,12 @@ public extension View {
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
-        _ title: @autoclosure @escaping () -> Text? = nil,
+        @ViewBuilder _ title: @escaping (Item) -> Text? = { _ in nil },
         item: Binding<Item?>,
         on windowScene: UIWindowScene,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
+    ) -> some View where Content: View, Actions: View {
         modifier(
             CustomAlertHandler(
                 item: item,
@@ -173,13 +173,13 @@ public extension View {
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
-        _ title: LocalizedStringKey,
+        _ title: @escaping (Item) -> LocalizedStringKey,
         item: Binding<Item?>,
         on windowScene: UIWindowScene,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
-        self.customAlert(Text(title), item: item, on: windowScene, content: content, actions: actions)
+    ) -> some View where Content: View, Actions: View {
+        self.customAlert({ item in Text(title(item)) }, item: item, on: windowScene, content: content, actions: actions)
     }
     
     /// Presents an alert when a given condition is true
@@ -200,13 +200,13 @@ public extension View {
     @warn_unqualified_access
     @_disfavoredOverload
     func customAlert<Item, Title, Content, Actions>(
-        _ title: Title,
+        _ title: @escaping (Item) -> Title,
         item: Binding<Item?>,
         on windowScene: UIWindowScene,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Title: StringProtocol, Content: View, Actions: View {
-        self.customAlert(Text(title), item: item, on: windowScene, content: content, actions: actions)
+    ) -> some View where Title: StringProtocol, Content: View, Actions: View {
+        self.customAlert({ item in Text(title(item)) }, item: item, on: windowScene, content: content, actions: actions)
     }
     
     /// Presents an alert when a given condition is true, using an optional text view for
@@ -222,18 +222,18 @@ public extension View {
     ///     the system dismisses the alert and replaces it with a new one
     ///     using the same process.
     ///   - windowScene: The window scene to present the alert on.
-    ///   - title: Callback for the optional title of the alert.
+    ///   - title: A `ViewBuilder` returing the alerts title.
     ///   - content: A `ViewBuilder` returing the alerts main view.
     ///   - actions: A `ViewBuilder` returning the alert's actions.
     @warn_unqualified_access
     func customAlert<Item, Content, Actions>(
         item: Binding<Item?>,
         on windowScene: UIWindowScene,
-        title: @escaping () -> Text?,
+        @ViewBuilder title: @escaping (Item) -> Text?,
         @ViewBuilder content: @escaping (Item) -> Content,
         @ViewBuilder actions: @escaping (Item) -> Actions
-    ) -> some View where Item: Identifiable, Content: View, Actions: View {
-        self.customAlert(title(), item: item, on: windowScene, content: content, actions: actions)
+    ) -> some View where Content: View, Actions: View {
+        self.customAlert({ title($0) }, item: item, on: windowScene, content: content, actions: actions)
     }
 }
 
@@ -257,8 +257,8 @@ public extension View {
         _ title: Text? = nil,
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View where Item: Identifiable, Content: View {
-        self.customAlert(title, item: item, content: content, actions: { _ in /* no actions */ })
+    ) -> some View where Content: View {
+        self.customAlert({ _ in title }, item: item, content: content, actions: { _ in /* no actions */ })
     }
     
     /// Presents an alert when a given condition is true, using
@@ -277,11 +277,11 @@ public extension View {
     ///   - content: A `ViewBuilder` returing the alerts main view.
     @warn_unqualified_access
     func customAlert<Item, Content>(
-        _ title: LocalizedStringKey,
+        _ title: @escaping (Item) -> LocalizedStringKey,
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View where Item: Identifiable, Content: View {
-        self.customAlert(Text(title), item: item, content: content, actions: { _ in /* no actions */ })
+    ) -> some View where Content: View {
+        self.customAlert({ Text(title($0)) }, item: item, content: content, actions: { _ in /* no actions */ })
     }
     
     /// Presents an alert when a given condition is true
@@ -300,11 +300,11 @@ public extension View {
     @warn_unqualified_access
     @_disfavoredOverload
     func customAlert<Item, Title, Content>(
-        _ title: Title,
+        _ title: @escaping (Item) -> Title,
         item: Binding<Item?>,
         @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View where Item: Identifiable, Title: StringProtocol, Content: View {
-        self.customAlert(Text(title), item: item, content: content, actions: { _ in /* no actions */ })
+    ) -> some View where Title: StringProtocol, Content: View {
+        self.customAlert({ Text(title($0)) }, item: item, content: content, actions: { _ in /* no actions */ })
     }
     
     /// Presents an alert when a given condition is true, using an optional text view for
@@ -319,14 +319,14 @@ public extension View {
     ///     create that the system displays to the user. If `item` changes,
     ///     the system dismisses the alert and replaces it with a new one
     ///     using the same process.
-    ///   - title: Callback for the optional title of the alert.
+    ///   - title: A `ViewBuilder` returing the alerts title.
     ///   - content: A `ViewBuilder` returing the alerts main view.
     @warn_unqualified_access
     func customAlert<Item, Content>(
         item: Binding<Item?>,
-        title: @escaping () -> Text?,
+        @ViewBuilder title: @escaping (Item) -> Text?,
         @ViewBuilder content: @escaping (Item) -> Content
-    ) -> some View where Item: Identifiable, Content: View {
-        self.customAlert(title(), item: item, content: content, actions: { _ in /* no actions */ })
+    ) -> some View where Content: View {
+        self.customAlert({ title($0) }, item: item, content: content, actions: { _ in /* no actions */ })
     }
 }

--- a/Sources/CustomAlert/CustomAlertHandler.swift
+++ b/Sources/CustomAlert/CustomAlertHandler.swift
@@ -9,19 +9,19 @@ import SwiftUI
 import Combine
 import WindowKit
 
-struct CustomAlertHandler<AlertItem, AlertContent, AlertActions>: ViewModifier where AlertItem: Identifiable, AlertContent: View, AlertActions: View {
+struct CustomAlertHandler<AlertItem, AlertContent, AlertActions>: ViewModifier where AlertContent: View, AlertActions: View {
     @Environment(\.customAlertConfiguration) private var configuration
     
     @Binding var item: AlertItem?
     var windowScene: UIWindowScene?
-    var alertTitle: () -> Text?
+    var alertTitle: (AlertItem) -> Text?
     @ViewBuilder var alertContent: (AlertItem) -> AlertContent
     @ViewBuilder var alertActions: (AlertItem) -> AlertActions
     
     init(
         item: Binding<AlertItem?>,
         windowScene: UIWindowScene? = nil,
-        alertTitle: @escaping () -> Text?,
+        alertTitle: @escaping (AlertItem) -> Text?,
         @ViewBuilder alertContent: @escaping (AlertItem) -> AlertContent,
         @ViewBuilder alertActions: @escaping (AlertItem) -> AlertActions
     ) {
@@ -61,7 +61,7 @@ struct CustomAlertHandler<AlertItem, AlertContent, AlertActions>: ViewModifier w
     @ViewBuilder var alertView: some View {
         if let item {
             CustomAlert(isPresented: isPresented) {
-                alertTitle()
+                alertTitle(item)
             } content: {
                 alertContent(item)
             } actions: {
@@ -81,7 +81,7 @@ struct CustomAlertHandler<AlertItem, AlertContent, AlertActions>: ViewModifier w
     @ViewBuilder var alertIdentity: some View {
         if let item {
             ZStack {
-                alertTitle()
+                alertTitle(item)
                 alertContent(item)
                 alertActions(item)
             }
@@ -101,7 +101,7 @@ struct CustomAlertHandler<AlertItem, AlertContent, AlertActions>: ViewModifier w
     }
 }
 
-extension CustomAlertHandler where AlertItem == AlertIdentifiable {
+extension CustomAlertHandler where AlertItem == OptionalBoolConvertible {
     init(
         isPresented: Binding<Bool>,
         windowScene: UIWindowScene?,
@@ -111,7 +111,7 @@ extension CustomAlertHandler where AlertItem == AlertIdentifiable {
     ) {
         self._item = Binding(bool: isPresented)
         self.windowScene = windowScene
-        self.alertTitle = alertTitle
+        self.alertTitle = { _ in alertTitle() }
         self.alertContent = { _ in alertContent() }
         self.alertActions = { _ in alertActions() }
     }

--- a/Sources/CustomAlert/OptionalBoolConvertible.swift
+++ b/Sources/CustomAlert/OptionalBoolConvertible.swift
@@ -1,5 +1,5 @@
 //
-//  AlertIdentifiable.swift
+//  OptionalBoolConvertible.swift
 //  CustomAlert
 //
 //  Created by David Walter on 31.03.24.
@@ -7,15 +7,13 @@
 
 import SwiftUI
 
-enum AlertIdentifiable: Int, Identifiable, Hashable, Equatable {
+enum OptionalBoolConvertible {
     case present
-    
-    var id: Int { rawValue }
 }
 
-extension Binding where Value == AlertIdentifiable? {
+extension Binding where Value == OptionalBoolConvertible? {
     init(bool binding: Binding<Bool>) {
-        self = Binding<AlertIdentifiable?> {
+        self = Binding<OptionalBoolConvertible?> {
             if binding.wrappedValue {
                 return .present
             } else {


### PR DESCRIPTION
Correct me if I'm wrong, but CustomAlertHandler doesn't need AlertItem to be Identifiable. CustomAlertHandler's item Binding (Binding<AlertItem?>) is used to nil check the item and it's Identifiable constraints are not used. Also refactored AlertIdentifiable for the same reason. 